### PR TITLE
V1.0: React Rendering issue fix.

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,4 +1,5 @@
 require('babel-polyfill');
+var React = require('react');
 var ReactDOM = require('react-dom');
 
 var Person = require('./components/person');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,13 @@ module.exports = {
           test: /\.js$/,
           exclude: /(node_modules)/,
           loader: 'babel',
-        },
+          query: {
+              presets: ['es2015', 'react']
+          }
+        }
       ]
-    }
+    },
+    resolve: {
+    extensions: ['', '.js', '.jsx']
+    },
 };


### PR DESCRIPTION
Ok so yes you do need `var React = require('react');`. That is a must.

The issue was in your webpack.config.js file.

You must have:

```
query: {
                    presets: ['es2015', 'react']
                }
```

and

```
resolve: {
    extensions: ['', '.js', '.jsx']
    },
```

Babel does not just automagically work if you import it. so you have to say look for these `presets` and `resolve` any files that end in the following so they all will be `.js` doesn't matter if you say `.js` or `.jsx`. JSX files are specifically files that have React code in them meaning html in the JS. Web pack will change the JSX files over to JS for the browser to read but only if you tell it to do so.
